### PR TITLE
changed readme from require('contrast-security') to require('contrast-sdk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Any method of the SDK that interacts with our API returns a promise.
 > **Note:** The Contrast URL is optional and defaults to https://app.contrastsecurity.com/Contrast/api
 
 ```javascript
-    var ContrastSdk = require('contrast-security');    
+    var ContrastSdk = require('contrast-sdk');    
     var contrastSdk = new ContrastSdk('username','api_key','service_key','teamserver_url');
 ```
 


### PR DESCRIPTION
After testing using the require statements require('contrast-security') and require('contrast-sdk) I was able to successfully use contrast-sdk. Therefore this PR changed the readme to reflect that.